### PR TITLE
Reconcile segment membership in SQL instead of a CSV round trip

### DIFF
--- a/config/stickle.php
+++ b/config/stickle.php
@@ -138,11 +138,60 @@ return [
     |
     | Stickle needs to save some files, such as exports, usually temporarily.
     | This defines the filesystem disk to use for these files.
+    |
+    | Only used when segments.useCsvExports is true. The default segment sync
+    | runs entirely inside PostgreSQL and writes no files.
     */
     'filesystem' => [
         'disks' => [
             'exports' => env('STICKLE_FILESYSTEM_DISK_EXPORTS', 'local'),
         ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Segments
+    |--------------------------------------------------------------------------
+    |
+    | useCsvExports selects how a segment's membership is reconciled.
+    |
+    | FALSE (default) — SyncSegmentAction reconciles membership in a single
+    | SQL statement. Both ends of the operation are the same database, so no
+    | file, no external binary, and no shared disk are involved. A failure
+    | raises a PDO exception rather than passing silently.
+    |
+    | TRUE — the legacy ExportSegmentAction/ImportSegmentAction pair: the
+    | segment query is written to a CSV, handed to a second queued job, and
+    | loaded back with a `psql \copy`. Only enable this if you specifically
+    | need it. It carries real operational requirements and known hazards:
+    |
+    |   * Requires the `psql` binary on every worker that runs
+    |     ImportSegmentJob. It is shelled out to via exec(). If psql is absent
+    |     the COPY fails, the exit code is discarded, and the reconciliation
+    |     proceeds against an EMPTY temp table — which deletes the segment's
+    |     entire membership and fires a spurious EXIT for every member. The
+    |     job still reports success.
+    |
+    |   * Requires a shared exports disk. ExportSegmentJob and ImportSegmentJob
+    |     are separate queued jobs, so on any multi-instance or containerised
+    |     host (Cloud Run, ECS, Kubernetes, multiple queue workers) they will
+    |     not share a local filesystem. 'local' works only when a single
+    |     machine runs both jobs; anything else needs a shared disk (s3, gcs).
+    |
+    |   * Leaks the database password. loadTmpTable() interpolates the password
+    |     into a shell string as PGPASSWORD=..., where it is visible in the
+    |     process list to any local user.
+    |
+    |   * Is broken by $appends. The export builds each CSV row from the model's
+    |     toArray(), which includes appended accessors — so any model declaring
+    |     protected $appends emits extra columns and the COPY fails with
+    |     "extra data after last expected column". The SQL path never hydrates
+    |     models and is unaffected.
+    |
+    | Both paths are equivalent in result and both are idempotent.
+    */
+    'segments' => [
+        'useCsvExports' => env('STICKLE_USE_CSV_EXPORTS', false),
     ],
 
     /*

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -152,7 +152,48 @@ Filesystem disk configurations for different storage needs.
 
 Laravel filesystem disk to use for storing segment exports and related files.
 
+Only used when [`STICKLE_USE_CSV_EXPORTS`](#stickle_use_csv_exports) is `true`. The
+default segment sync writes no files.
+
 _Default: 'local'_
+
+## Segments
+
+### `STICKLE_USE_CSV_EXPORTS`
+
+Selects how a segment's membership is reconciled.
+
+_Default: `false`_
+
+#### `false` (default) — in-database sync
+
+`SyncSegmentAction` reconciles membership in a single SQL statement. Both ends of the
+operation are the same database, so no file, no external binary and no shared disk are
+involved, and a failure raises a PDO exception rather than passing silently.
+
+#### `true` — legacy CSV round trip
+
+`ExportSegmentAction` writes the segment query to a CSV, hands the filename to a second
+queued job (`ImportSegmentJob`), which loads it back with a `psql \copy`. Both paths are
+equivalent in result and both are idempotent, so enable this only if you specifically
+need it. It carries real requirements and known hazards:
+
+- **Requires the `psql` binary** on every worker that runs `ImportSegmentJob` — it is
+  shelled out to via `exec()`. If `psql` is missing the COPY fails, its exit code is
+  discarded, and reconciliation proceeds against an **empty temp table**, deleting the
+  segment's entire membership and firing a spurious `EXIT` for every member. The job
+  still reports success.
+- **Requires a shared exports disk.** `ExportSegmentJob` and `ImportSegmentJob` are
+  separate queued jobs, so on any multi-instance or containerised host (Cloud Run, ECS,
+  Kubernetes, or simply more than one queue worker) they will not share a local
+  filesystem, and the import fails with `File missing`. `local` is only safe when a
+  single machine runs both jobs; anything else needs `s3`, `gcs`, or similar.
+- **Leaks the database password.** The import interpolates it into a shell string as
+  `PGPASSWORD=…`, where it is visible in the process list to any local user.
+- **Is broken by `$appends`.** Each CSV row is built from the model's `toArray()`, which
+  includes appended accessors — so any model declaring `protected $appends` emits extra
+  columns and the COPY fails with `extra data after last expected column`. The default
+  SQL path never hydrates models and is unaffected.
 
 ## Routes
 

--- a/src/Actions/SyncSegmentAction.php
+++ b/src/Actions/SyncSegmentAction.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StickleApp\Core\Actions;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use StickleApp\Core\Contracts\SegmentContract;
+
+/**
+ * Reconciles a segment's membership entirely inside PostgreSQL.
+ *
+ * This is the default replacement for the CSV export/import pair
+ * (ExportSegmentAction + ImportSegmentAction), which round-tripped the segment
+ * query out of the database into a CSV and back in via a `psql \copy`
+ * shell-out. Both ends of that round trip are the same database, so the file
+ * bought nothing and cost a shared disk, a psql binary, and a silent failure
+ * mode. See config('stickle.segments.useCsvExports') for the legacy path.
+ *
+ * The statement below preserves the two properties the CSV design existed to
+ * protect:
+ *
+ *  - **Materialization boundary.** `src` is a MATERIALIZED CTE, so the segment
+ *    query is evaluated once, up front, taking only ACCESS SHARE on the source
+ *    tables and holding no write lock on model_segment while it runs. The
+ *    membership write happens afterwards, against the materialized set. This is
+ *    the same read-then-merge split the temp table provided — it is what keeps
+ *    a long segment query from holding a write lock on model_segment for its
+ *    whole duration.
+ *  - **created_at preservation.** `ON CONFLICT DO NOTHING` leaves existing rows
+ *    untouched, so a member's original entry timestamp survives re-runs. Only
+ *    genuinely new members are inserted, which also keeps the audit trigger
+ *    from emitting spurious ENTER/EXIT events on every sync.
+ *
+ * `ORDER BY object_uid` + `FOR UPDATE` make every concurrent sync acquire row
+ * locks in the same order, so two overlapping runs of the same segment cannot
+ * form a deadlock cycle. (ExportSegmentJob's WithoutOverlapping lock expires
+ * after $uniqueFor seconds, so a slow sync can legitimately overlap its own
+ * next run.) SKIP LOCKED is deliberately NOT used: it would silently drop
+ * contended rows from the reconciliation to buy protection against a deadlock
+ * that consistent ordering already prevents.
+ */
+class SyncSegmentAction
+{
+    public function __invoke(
+        int $segmentId,
+        SegmentContract $segmentContract,
+    ): void {
+        Log::debug(self::class, ['segment_id' => $segmentId]);
+
+        $builder = $segmentContract->toBuilder();
+        $model = $builder->getModel();
+
+        // object_uid is a text column; cast explicitly so the join in the
+        // reconciliation below does not hit a bigint/text type mismatch.
+        $builder->selectRaw(
+            $model->getTable().'.'.$model->getKeyName().'::text as object_uid'
+        );
+
+        /** @var string $prefix */
+        $prefix = config('stickle.database.tablePrefix');
+
+        $table = $prefix.'model_segment';
+
+        $sql = <<<SQL
+        WITH src AS MATERIALIZED (
+            SELECT DISTINCT sub.object_uid FROM ({$builder->toSql()}) sub
+        ),
+        stale AS (
+            SELECT      ms.object_uid
+            FROM        {$table} ms
+            WHERE       ms.segment_id = ?
+            AND         NOT EXISTS (
+                            SELECT 1 FROM src WHERE src.object_uid = ms.object_uid
+                        )
+            ORDER BY    ms.object_uid
+            FOR UPDATE
+        ),
+        removed AS (
+            DELETE FROM {$table} ms
+            WHERE       ms.segment_id = ?
+            AND         ms.object_uid IN (SELECT object_uid FROM stale)
+        )
+        INSERT INTO     {$table} (object_uid, segment_id, created_at, updated_at)
+        SELECT          src.object_uid, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+        FROM            src
+        ORDER BY        src.object_uid
+        ON CONFLICT     (object_uid, segment_id) DO NOTHING;
+        SQL;
+
+        DB::statement($sql, [
+            ...$builder->getBindings(),
+            $segmentId,
+            $segmentId,
+            $segmentId,
+        ]);
+    }
+}

--- a/src/Jobs/ExportSegmentJob.php
+++ b/src/Jobs/ExportSegmentJob.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Support\Facades\Log;
 use StickleApp\Core\Actions\ExportSegmentAction;
+use StickleApp\Core\Actions\SyncSegmentAction;
 use StickleApp\Core\Contracts\SegmentContract;
 use StickleApp\Core\Models\Segment;
 
@@ -44,8 +45,10 @@ class ExportSegmentJob implements ShouldQueue
         return [new WithoutOverlapping($this->uniqueId())];
     }
 
-    public function handle(ExportSegmentAction $exportSegmentAction): void
-    {
+    public function handle(
+        ExportSegmentAction $exportSegmentAction,
+        SyncSegmentAction $syncSegmentAction,
+    ): void {
 
         Log::debug('ExportSegment Job', ['segment' => $this->segment]);
 
@@ -53,6 +56,19 @@ class ExportSegmentJob implements ShouldQueue
 
         /** @var SegmentContract $segment */
         $segment = new $class;
+
+        // Default: reconcile in-database, no file and no second job.
+        if (! config('stickle.segments.useCsvExports', false)) {
+            $syncSegmentAction(
+                segmentId: $this->segment->id,
+                segmentContract: $segment
+            );
+
+            return;
+        }
+
+        // Legacy CSV round trip — see config('stickle.segments.useCsvExports')
+        // for its requirements (psql binary, shared exports disk) and hazards.
         $exportFilename = $exportSegmentAction(
             segmentId: $this->segment->id,
             segmentContract: $segment

--- a/tests/Unit/Actions/SyncSegmentTest.php
+++ b/tests/Unit/Actions/SyncSegmentTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use StickleApp\Core\Actions\SyncSegmentAction;
+use StickleApp\Core\Models\Segment as SegmentModel;
+use Workbench\App\Models\User;
+use Workbench\App\Segments\AllUsers;
+
+beforeEach(function (): void {
+    $this->prefix = config('stickle.database.tablePrefix');
+
+    $this->segment = SegmentModel::query()->create([
+        'name' => 'All Users',
+        'model_class' => 'User',
+        'as_class' => 'AllUsers',
+        'description' => 'The users.',
+    ]);
+
+    $this->members = fn (): int => DB::table($this->prefix.'model_segment')
+        ->where('segment_id', $this->segment->id)
+        ->count();
+
+    $this->audit = fn (string $operation): int => DB::table($this->prefix.'model_segment_audit')
+        ->where('segment_id', $this->segment->id)
+        ->where('operation', $operation)
+        ->count();
+});
+
+it('populates membership from the segment query', function (): void {
+    User::factory()->count(3)->create();
+
+    (new SyncSegmentAction)($this->segment->id, new AllUsers);
+
+    expect(($this->members)())->toBe(3)
+        ->and(($this->audit)('ENTER'))->toBe(3)
+        ->and(($this->audit)('EXIT'))->toBe(0);
+});
+
+it('is idempotent and preserves created_at across re-runs', function (): void {
+    User::factory()->count(3)->create();
+
+    (new SyncSegmentAction)($this->segment->id, new AllUsers);
+
+    $createdAt = DB::table($this->prefix.'model_segment')
+        ->where('segment_id', $this->segment->id)
+        ->orderBy('object_uid')
+        ->value('created_at');
+
+    (new SyncSegmentAction)($this->segment->id, new AllUsers);
+    (new SyncSegmentAction)($this->segment->id, new AllUsers);
+
+    $createdAtAfter = DB::table($this->prefix.'model_segment')
+        ->where('segment_id', $this->segment->id)
+        ->orderBy('object_uid')
+        ->value('created_at');
+
+    // Membership unchanged, entry timestamps untouched, and — critically — the
+    // audit trigger did not emit a second round of ENTER events.
+    expect(($this->members)())->toBe(3)
+        ->and($createdAtAfter)->toEqual($createdAt)
+        ->and(($this->audit)('ENTER'))->toBe(3)
+        ->and(($this->audit)('EXIT'))->toBe(0);
+});
+
+it('removes members that no longer match and records a single exit', function (): void {
+    $users = User::factory()->count(3)->create();
+
+    (new SyncSegmentAction)($this->segment->id, new AllUsers);
+    expect(($this->members)())->toBe(3);
+
+    $users->first()->delete();
+
+    (new SyncSegmentAction)($this->segment->id, new AllUsers);
+
+    expect(($this->members)())->toBe(2)
+        ->and(($this->audit)('EXIT'))->toBe(1)
+        ->and(($this->audit)('ENTER'))->toBe(3);
+});
+
+it('reconciles an empty segment to empty without error', function (): void {
+    (new SyncSegmentAction)($this->segment->id, new AllUsers);
+
+    expect(($this->members)())->toBe(0);
+});
+
+it('does not wipe membership when the segment query yields no rows for another segment', function (): void {
+    User::factory()->count(2)->create();
+
+    // Distinct as_class only to satisfy the (model_class, as_class) unique
+    // index — the action is handed its SegmentContract explicitly, so the
+    // stored class name is irrelevant here. What matters is the segment_id.
+    $otherSegmentId = SegmentModel::query()->create([
+        'name' => 'Other',
+        'model_class' => 'User',
+        'as_class' => 'ActiveUsers',
+        'description' => 'Other segment.',
+    ])->id;
+
+    (new SyncSegmentAction)($this->segment->id, new AllUsers);
+
+    // Syncing a different segment must not touch this one's rows.
+    (new SyncSegmentAction)($otherSegmentId, new AllUsers);
+
+    expect(($this->members)())->toBe(2)
+        ->and(($this->audit)('EXIT'))->toBe(0);
+});

--- a/tests/Unit/Jobs/ExportSegmentJobTest.php
+++ b/tests/Unit/Jobs/ExportSegmentJobTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use StickleApp\Core\Actions\ExportSegmentAction;
+use StickleApp\Core\Actions\SyncSegmentAction;
+use StickleApp\Core\Jobs\ExportSegmentJob;
+use StickleApp\Core\Jobs\ImportSegmentJob;
+use StickleApp\Core\Models\Segment as SegmentModel;
+use Workbench\App\Models\User;
+
+beforeEach(function (): void {
+    Bus::fake();
+    Storage::fake('local');
+
+    $this->prefix = config('stickle.database.tablePrefix');
+
+    $this->segment = SegmentModel::query()->create([
+        'name' => 'All Users',
+        'model_class' => 'User',
+        'as_class' => 'AllUsers',
+        'description' => 'The users.',
+    ]);
+
+    $this->handle = fn () => (new ExportSegmentJob($this->segment))->handle(
+        resolve(ExportSegmentAction::class),
+        resolve(SyncSegmentAction::class),
+    );
+});
+
+it('reconciles in-database and dispatches no import job by default', function (): void {
+    config()->set('stickle.segments.useCsvExports', false);
+
+    User::factory()->count(2)->create();
+
+    ($this->handle)();
+
+    Bus::assertNotDispatched(ImportSegmentJob::class);
+
+    expect(DB::table($this->prefix.'model_segment')
+        ->where('segment_id', $this->segment->id)
+        ->count())->toBe(2);
+});
+
+it('writes no export file by default', function (): void {
+    config()->set('stickle.segments.useCsvExports', false);
+    config()->set('stickle.filesystem.disks.exports', 'local');
+
+    User::factory()->count(2)->create();
+
+    ($this->handle)();
+
+    // The SQL path touches no filesystem at all — this is what removes the
+    // shared-disk requirement on multi-instance hosts.
+    expect(Storage::disk('local')->allFiles())->toBeEmpty();
+});
+
+it('falls back to the CSV round trip when useCsvExports is enabled', function (): void {
+    config()->set('stickle.segments.useCsvExports', true);
+    config()->set('stickle.filesystem.disks.exports', 'local');
+
+    User::factory()->count(2)->create();
+
+    ($this->handle)();
+
+    Bus::assertDispatched(ImportSegmentJob::class);
+
+    // The CSV path defers the write to ImportSegmentJob, so membership is not
+    // reconciled synchronously the way the SQL path does.
+    expect(DB::table($this->prefix.'model_segment')
+        ->where('segment_id', $this->segment->id)
+        ->count())->toBe(0);
+});


### PR DESCRIPTION
## Summary

Adds `SyncSegmentAction`, which reconciles a segment's membership in a **single SQL statement**, and makes it the default path for `ExportSegmentJob`. The existing CSV export/import pair is kept, unchanged, behind `STICKLE_USE_CSV_EXPORTS` (default `false`).

Both ends of the export/import were always the same database. The CSV round trip bought nothing and cost a shared disk, a `psql` binary, and a silent failure mode.

## Why

### The CSV path can silently delete a segment

`ImportSegmentAction::loadTmpTable()` shells out to `psql` via `exec($cmd, $output, $res)` and **never checks `$res`**. If the COPY fails for any reason, execution continues to `executeQuery()` with an **empty temp table** — and `f_deactivate_model_segments` is a `LEFT JOIN temp … WHERE temp.object_uid IS NULL → DELETE`. An empty temp table matches every member.

Reproduced end-to-end against a real database:

| | before | after |
|---|---|---|
| `model_segment` | 80 members | **0** |
| `model_segment_audit` | 80 ENTER | 80 ENTER + **80 EXIT** |
| `model_segment_statistics` | — | **80 rows** stamped `last_exit_recorded_at` |
| job exit code | | **0** |

Membership is derived and recovers on the next successful sync, but the audit trail and statistics do not — the trigger writes a permanent, false mass-exit event. And because no exception is raised, monitoring never fires.

### It is also broken by `$appends`, on any host

Each CSV row is built from the model's `toArray()`, which includes appended accessors. Any model declaring `protected $appends` emits an extra column and the COPY dies on row 1:

```
ERROR:  extra data after last expected column
CONTEXT:  COPY _segment_2_…, line 1: "1,2,"
```

This is independent of the deployment topology — it reproduces on a plain local install.

### And it needs a shared disk it usually doesn't have

`ExportSegmentJob` and `ImportSegmentJob` are separate queued jobs, so on any multi-instance or containerised host (Cloud Run, ECS, Kubernetes, or just >1 queue worker) they don't share a filesystem, and the import fails with `File missing`. The `local` default is only safe on a single machine.

## What the new statement preserves

The CSV design existed to protect two properties, and both survive:

- **The materialization boundary.** `src` is a `MATERIALIZED` CTE, so the segment query is evaluated once, up front, taking only `ACCESS SHARE` on the source tables and holding **no write lock on `model_segment` while it runs**. The merge then happens against the materialized set. This is the same read-then-merge split the temp table provided — it's what stops a long segment query from pinning a write lock on `model_segment` for its whole duration. The CSV was never what protected this; the materialization was, and the file was just an expensive medium for it.
- **`created_at` preservation.** `ON CONFLICT DO NOTHING` leaves existing rows untouched, so entry timestamps survive re-runs and the audit trigger emits no ENTER/EXIT churn — the same thing `f_activate_model_segments`' not-already-present check protects.

`ORDER BY object_uid` + `FOR UPDATE` make every concurrent sync acquire row locks in the same order, so two overlapping runs of one segment cannot form a deadlock cycle. This matters because `ExportSegmentJob`'s `WithoutOverlapping` lock expires after `$uniqueFor` (120s), so a slow sync can legitimately overlap its own next run.

`SKIP LOCKED` is **deliberately not used** — it would silently drop contended rows from the reconciliation to buy protection against a deadlock that consistent ordering already prevents.

## Honest limits

I could **not** reproduce a deadlock in either the old or new design — not at 80 rows, not at 60k rows × 6 concurrent, with or without `ORDER BY`. Every import runs the same statement shape, so every transaction gets the same plan and acquires locks in the same order. The ordering here is therefore cheap insurance, not a demonstrated fix. Testing was on PostgreSQL 16 with `generate_series` and workbench segments; real segment queries on other versions may plan differently.

## Test plan

New `tests/Unit/Actions/SyncSegmentTest.php` (real Postgres, real triggers):
- populates membership from the segment query
- **idempotent across re-runs** — `created_at` unchanged, no duplicate ENTER events
- removes non-matching members and records exactly one EXIT
- reconciles an empty segment to empty
- syncing one segment does not touch another's rows

New `tests/Unit/Jobs/ExportSegmentJobTest.php`:
- default: reconciles in-database, dispatches no `ImportSegmentJob`, writes no file
- `useCsvExports = true`: falls back to the CSV round trip and dispatches `ImportSegmentJob`

Gates:
- `pest` — **228 passed**, 1 skipped (pre-existing)
- `phpstan` level 8 — no errors
- `pint` — passed
- `rector --dry-run` — 44 files, **unchanged from `main`'s baseline**; the pre-existing findings are left alone to keep this diff scoped

## Compatibility

Default-off for the new behaviour is not possible without keeping the bug, so the flag defaults to the SQL path and existing installs can opt back with `STICKLE_USE_CSV_EXPORTS=true`. `ExportSegmentAction`, `ImportSegmentAction`, `ImportSegmentJob` and their tests are untouched. `ExportSegmentJob::handle()` takes a second injected argument — a behaviour change only for anyone calling `handle()` directly.
