### PR TITLE
Take the nanoid patch that clears the last open Dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2454,15 +2454,16 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },


### PR DESCRIPTION
Closes the one open Dependabot alert on the repository, **GHSA-2v37-7h3g-55p8** (high): `nanoid` below 3.3.18 loops indefinitely when a custom generator is given a size of zero.

It arrives transitively — `vite` → `postcss` → `nanoid` — and `postcss` already allows `^3.3.16`, so only the lockfile needed to move. One file, four lines, no dependency added or removed.

### Verification

- `npm audit` → **0 vulnerabilities**
- `npm run build` reproduces `public/build` byte for byte: `app-DUd60qJI.css`, `app-l0sNRNKZ.js` and `manifest.json` all keep their hashes, so no consuming application's published assets change and `assets-are-current` stays green
- `npm run docs:build` still succeeds

### Scope, for the record

Nothing here reached a consuming application. `nanoid` is a build-time dependency of a PHP package: the artifact that ships is the committed `public/build`, which does not contain it, and consumers never run `npm install`.

The same is true of the PHP side, which Dependabot does not report on because `composer.lock` is deliberately untracked for a library. `composer audit` currently lists 35 advisories across guzzle, symfony, `league/commonmark` and `laravel/framework` — every one of them arriving through `require-dev` (`orchestra/testbench`, `laravel/boost`). This package requires only `php`, `illuminate/contracts` and `laravel/prompts`, and Composer does not install a dependency's `require-dev`, so none are reachable from an installing application. There is also no lockfile in which to pin a fix; they resolve fresh on every CI run.

No action taken on those, deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iDeNdEVXrsSmo3TTDG68o