### PR TITLE
Repair the rollup functions with a migration instead of a loose SQL file

### DIFF
--- a/database/migrations/2026-08-26-120000_redefine_rollup_request_functions.php
+++ b/database/migrations/2026-08-26-120000_redefine_rollup_request_functions.php
@@ -1,11 +1,50 @@
-CREATE OR REPLACE FUNCTION stc_rollup_requests_1min(OUT start_id bigint, OUT end_id bigint)
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Redefine the request rollup functions.
+     *
+     * The four functions were created by 2025-03-04-000200_analytics without a
+     * column list on their INSERT ... SELECT. The rollup tables declare
+     * object_uid before model_class while the SELECT produces model_class
+     * first, so Postgres mapped them positionally and every aggregated row had
+     * the two transposed -- model_class held object uids. Every filter that
+     * compares model_class therefore matched nothing.
+     *
+     * That migration has already run everywhere, and Laravel never re-runs a
+     * migration, so correcting it in place only helps a fresh install. This
+     * migration exists to carry the same correction to databases that already
+     * have the broken definitions.
+     *
+     * CREATE OR REPLACE touches no data and no bookmarks, so this is a no-op
+     * on a database created after the fix, and safe to run more than once.
+     *
+     * It deliberately does not repair rows already aggregated by the broken
+     * functions -- those have the columns transposed and there is no in-place
+     * fix for them. Truncating the rollup tables and resetting
+     * last_aggregated_id in {prefix}rollups rebuilds them correctly; see the
+     * upgrade notes.
+     */
+    public function up(): void
+    {
+        $prefix = config('stickle.database.tablePrefix');
+
+        DB::connection()->getPdo()->exec("
+-- ----------------------------------------------------------------------------
+-- REQUESTS 1 MINUTE AGGREGATION
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION {$prefix}rollup_requests_1min(OUT start_id bigint, OUT end_id bigint)
 RETURNS record
 AS
 $$
 BEGIN
     /* determine which requests we can safely aggregate */
     SELECT window_start, window_end INTO start_id, end_id
-    FROM stc_incremental_rollup_window('stc_requests_rollup_1min');
+    FROM {$prefix}incremental_rollup_window('{$prefix}requests_rollup_1min');
 
     /* exit early if there are no new events to aggregate */
     IF start_id > end_id THEN RETURN; END IF;
@@ -14,7 +53,7 @@ BEGIN
     /* The column list is required, not decorative: the table declares
        object_uid before model_class, so an unqualified INSERT maps this
        SELECT positionally and silently transposes the two. */
-    INSERT INTO stc_requests_rollup_1min
+    INSERT INTO {$prefix}requests_rollup_1min
         (model_class, object_uid, type, name, title, path, url, minute, request_count)
         SELECT  model_class,
                 object_uid,
@@ -25,23 +64,26 @@ BEGIN
                 properties->>'url' as url,
                 date_trunc('seconds', (timestamp - TIMESTAMP 'epoch') / 60) * 60 + TIMESTAMP 'epoch' AS minute,
                 count(*) as request_count
-        FROM stc_requests WHERE stc_requests.id BETWEEN start_id AND end_id
+        FROM {$prefix}requests WHERE {$prefix}requests.id BETWEEN start_id AND end_id
         GROUP BY model_class, object_uid, type, name, title, path, url, minute
         ON CONFLICT (model_class, object_uid, type, name, title, path, url, minute)
         DO UPDATE
-        SET request_count = stc_requests_rollup_1min.request_count + excluded.request_count;
+        SET request_count = {$prefix}requests_rollup_1min.request_count + excluded.request_count;
 END; 
 $$
 LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION stc_rollup_requests_5min(OUT start_id bigint, OUT end_id bigint)
+-- ----------------------------------------------------------------------------
+-- REQUESTS 5 MINUTE AGGREGATION
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION {$prefix}rollup_requests_5min(OUT start_id bigint, OUT end_id bigint)
 RETURNS record
 AS
 $$
 BEGIN
     /* determine which requests we can safely aggregate */
     SELECT window_start, window_end INTO start_id, end_id
-    FROM stc_incremental_rollup_window('stc_requests_rollup_5min');
+    FROM {$prefix}incremental_rollup_window('{$prefix}requests_rollup_5min');
 
     /* exit early if there are no new events to aggregate */
     IF start_id > end_id THEN RETURN; END IF;
@@ -50,7 +92,7 @@ BEGIN
     /* The column list is required, not decorative: the table declares
        object_uid before model_class, so an unqualified INSERT maps this
        SELECT positionally and silently transposes the two. */
-    INSERT INTO stc_requests_rollup_5min
+    INSERT INTO {$prefix}requests_rollup_5min
         (model_class, object_uid, type, name, title, path, url, minute, request_count)
         SELECT  model_class,
                 object_uid,
@@ -61,23 +103,26 @@ BEGIN
                 properties->>'url' as url,
                 date_trunc('seconds', (timestamp - TIMESTAMP 'epoch') / 300) * 300 + TIMESTAMP 'epoch' AS minute,
                 count(*) as request_count
-        FROM stc_requests WHERE stc_requests.id BETWEEN start_id AND end_id
+        FROM {$prefix}requests WHERE {$prefix}requests.id BETWEEN start_id AND end_id
         GROUP BY model_class, object_uid, type, name, title, path, url, minute
         ON CONFLICT (model_class, object_uid, type, name, title, path, url, minute)
         DO UPDATE
-        SET request_count = stc_requests_rollup_5min.request_count + excluded.request_count;
+        SET request_count = {$prefix}requests_rollup_5min.request_count + excluded.request_count;
 END; 
 $$
 LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION stc_rollup_requests_1hr(OUT start_id bigint, OUT end_id bigint)
+-- ----------------------------------------------------------------------------
+-- REQUESTS 1 HOUR AGGREGATION
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION {$prefix}rollup_requests_1hr(OUT start_id bigint, OUT end_id bigint)
 RETURNS record
 AS
 $$
 BEGIN
     /* determine which requests we can safely aggregate */
     SELECT window_start, window_end INTO start_id, end_id
-    FROM stc_incremental_rollup_window('stc_requests_rollup_1hr');
+    FROM {$prefix}incremental_rollup_window('{$prefix}requests_rollup_1hr');
 
     /* exit early if there are no new events to aggregate */
     IF start_id > end_id THEN RETURN; END IF;
@@ -86,7 +131,7 @@ BEGIN
     /* The column list is required, not decorative: the table declares
        object_uid before model_class, so an unqualified INSERT maps this
        SELECT positionally and silently transposes the two. */
-    INSERT INTO stc_requests_rollup_1hr
+    INSERT INTO {$prefix}requests_rollup_1hr
         (model_class, object_uid, type, name, title, path, url, hour, request_count)
         SELECT  model_class,
                 object_uid,
@@ -97,23 +142,26 @@ BEGIN
                 properties->>'url' as url,
                 date_trunc('hour', timestamp) as hour,
                 count(*) as request_count
-        FROM stc_requests WHERE stc_requests.id BETWEEN start_id AND end_id
+        FROM {$prefix}requests WHERE {$prefix}requests.id BETWEEN start_id AND end_id
         GROUP BY model_class, object_uid, type, name, title, path, url, hour
         ON CONFLICT (model_class, object_uid, type, name, title, path, url, hour)
         DO UPDATE
-        SET request_count = stc_requests_rollup_1hr.request_count + excluded.request_count;
+        SET request_count = {$prefix}requests_rollup_1hr.request_count + excluded.request_count;
 END; 
 $$
 LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION stc_rollup_requests_1day(OUT start_id bigint, OUT end_id bigint)
+-- ----------------------------------------------------------------------------
+-- REQUESTS 1 DAY AGGREGATION
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION {$prefix}rollup_requests_1day(OUT start_id bigint, OUT end_id bigint)
 RETURNS record
 AS
 $$
 BEGIN
     /* determine which requests we can safely aggregate */
     SELECT window_start, window_end INTO start_id, end_id
-    FROM stc_incremental_rollup_window('stc_requests_rollup_1day');
+    FROM {$prefix}incremental_rollup_window('{$prefix}requests_rollup_1day');
 
     /* exit early if there are no new events to aggregate */
     IF start_id > end_id THEN RETURN; END IF;
@@ -122,7 +170,7 @@ BEGIN
     /* The column list is required, not decorative: the table declares
        object_uid before model_class, so an unqualified INSERT maps this
        SELECT positionally and silently transposes the two. */
-    INSERT INTO stc_requests_rollup_1day
+    INSERT INTO {$prefix}requests_rollup_1day
         (model_class, object_uid, type, name, title, path, url, day, request_count)
         SELECT  model_class,
                 object_uid,
@@ -133,11 +181,21 @@ BEGIN
                 properties->>'url' as url,
                 date_trunc('day', timestamp) as day,
                 count(*) as request_count
-        FROM stc_requests WHERE stc_requests.id BETWEEN start_id AND end_id
+        FROM {$prefix}requests WHERE {$prefix}requests.id BETWEEN start_id AND end_id
         GROUP BY model_class, object_uid, type, name, title, path, url, day
         ON CONFLICT (model_class, object_uid, type, name, title, path, url, day)
         DO UPDATE
-        SET request_count = stc_requests_rollup_1day.request_count + excluded.request_count;
+        SET request_count = {$prefix}requests_rollup_1day.request_count + excluded.request_count;
 END; 
 $$
 LANGUAGE plpgsql;
+");
+    }
+
+    /**
+     * Irreversible by choice. Rolling back would mean restoring definitions
+     * that silently transpose two columns, which is not a state worth being
+     * able to return to.
+     */
+    public function down(): void {}
+};

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -441,17 +441,38 @@ functions inserted without naming their columns.
 
 ```sql
 SELECT proname,
-       position('(model_class, object_uid, type' in pg_get_functiondef(oid)) > 0
-         AS fixed
+       position('request_count)' in pg_get_functiondef(oid)) > 0 AS fixed
 FROM pg_proc
 WHERE proname LIKE 'stc_rollup_requests%'
 ORDER BY proname;
 ```
 
-Four rows reading `f` means your database still has the old functions. Because the
-fix was made to a migration that has already run, `php artisan migrate` will **not**
-apply it — the functions must be redefined explicitly, and any rows already
-aggregated discarded. See the upgrade notes for the exact sequence.
+Four rows reading `f` means your database still has the old functions.
+
+::: tip Match the INSERT, not the ON CONFLICT
+Both versions of the function name these columns in their `ON CONFLICT` clause, so
+searching for `(model_class, object_uid` reports every database as fixed. Only the
+corrected version names them on the `INSERT`, and `request_count)` closes that list.
+:::
+
+**The fix ships as a migration.** `2026-08-26-120000_redefine_rollup_request_functions`
+redefines all four, so `php artisan migrate` repairs an existing database. It uses
+`CREATE OR REPLACE`, touches no data and no bookmarks, and is a no-op where the
+definitions are already correct.
+
+Rows already aggregated by the broken functions still have the two columns
+transposed, and there is no in-place repair for them. The rollups are derived data —
+rebuild them:
+
+```sql
+TRUNCATE stc_requests_rollup_1min,
+         stc_requests_rollup_5min,
+         stc_requests_rollup_1hr,
+         stc_requests_rollup_1day;
+
+UPDATE stc_rollups SET last_aggregated_id = 0
+WHERE name LIKE 'stc_requests_rollup_%';
+```
 
 ### Requests Are Recorded but the Types Look Wrong
 


### PR DESCRIPTION
Replaces `database/upgrades/redefine-rollup-functions.sql` with a real migration, so `php artisan migrate` is the whole upgrade procedure.

### Why this is needed at all

The column-order fix in #40 was made by editing `2025-03-04-000200_analytics`, a migration that has already run everywhere. Laravel never re-runs a migration, so that correction only ever reached a **fresh install**. Every existing database kept functions whose `INSERT ... SELECT` named no columns — and therefore kept writing object uids into `model_class` and class names into `object_uid`, which is exactly what made every `model_class` filter match nothing.

Shipping the repair as a loose `.sql` file made it a step an operator had to know about and could silently skip. Now it is `2026-08-26-120000_redefine_rollup_request_functions`.

### Properties

- `CREATE OR REPLACE` touches no data and no bookmarks — a **no-op** where the definitions are already correct, and safe to run twice
- `down()` is empty on purpose: rolling back would restore definitions that silently transpose two columns
- Does **not** repair rows the broken functions already aggregated. Those have the columns transposed with no in-place fix; the rollups are derived data, so truncating them and resetting `last_aggregated_id` rebuilds them correctly. Troubleshooting now spells that out.

### The docs detection query was wrong

It searched for `'(model_class, object_uid, type'` — which **both** versions of the function contain, in their `ON CONFLICT` clause. Every database reported itself as already fixed. Only the corrected version names those columns on the `INSERT`, and `request_count)` closes that list:

```sql
SELECT proname,
       position('request_count)' in pg_get_functiondef(oid)) > 0 AS fixed
FROM pg_proc WHERE proname LIKE 'stc_rollup_requests%' ORDER BY proname;
```

### Verified

Against a live database, not by inspection:

1. Installed the pre-fix definitions from `42378f6`
2. Confirmed the corrected query reported all four as broken (the old query reported all four as fixed)
3. Ran `migrate` — all four repaired
4. Inserted a row, ran the rollup, confirmed `model_class` and `object_uid` land the right way round
5. `migrate` again — no-op
6. `migrate:fresh` — 13 migrations, functions correct, harmless on a database that never had the bug

280 tests, PHPStan level 8, Pint and Rector all clean. VitePress builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iDeNdEVXrsSmo3TTDG68o