### PR TITLE
Give the test suite its own APP_KEY so a clean checkout can run it

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,6 +29,15 @@
         </include>
     </source>
     <php>
+        <!--
+            The suite supplies its own APP_KEY. composer install runs
+            post-autoload-dump -> package:purge-skeleton, which deletes the
+            testbench skeleton's .env and never restores it, so on a clean
+            checkout every test touching encryption or a signed cookie raised
+            MissingAppKeyException. A throwaway key for tests only: not a
+            secret, and used nowhere else.
+        -->
+        <env name="APP_KEY" value="base64:2fl+Ktvkfl+Fuz4Qp/A75G2RTiWVA/ZoKZvp6fiiM10="/>
         <env name="DB_CONNECTION" value="pgsql"/>
         <env name="DB_DATABASE" value="postgres"/>
         <env name="DB_USERNAME" value="postgres"/>


### PR DESCRIPTION
`main` has been red since **2026-07-30** with `MissingAppKeyException` — thirteen tests across `WebGuardTest`, `ChannelGuardTest` and `TransportMiddlewareTest`. This is the standing failure every PR inherits, including #42.

### Cause

`phpunit.xml.dist` declares the database and namespace environment the suite needs, but never declared `APP_KEY`. The suite was relying on the testbench skeleton's `.env` — and that file does not survive an install:

```
composer install
  └─ post-autoload-dump
       └─ @clear → testbench package:purge-skeleton   ← deletes .env
```

Nothing puts it back. A machine that has run `package:sync-skeleton` at some point passes; a clean checkout — which CI is, every time — does not.

### Why here rather than in the workflow

Restoring the skeleton in `run-tests.yml` would also work, but it leaves the suite dependent on the order of install-time side effects. Declaring the key in the suite's own config means `vendor/bin/pest` works from any checkout state. The value is a throwaway used only by tests — not a secret, and used nowhere else.

### Verified by reproduction, not inference

1. Moved the skeleton `.env` aside to recreate CI's exact state
2. The same thirteen tests failed with the same exception
3. Applied this change — with `.env` still absent, they pass:
   ```
   Tests:  22 passed (52 assertions)
   ```
4. Full suite: **280 passed, 1 skipped**

PHPStan level 8, Pint and Rector clean.

---

### Separate finding, not fixed here

While diagnosing this I hit a second, unrelated problem worth its own issue: **the suite leaks three PostgreSQL column slots per run.**

`workbench/database/migrations/2025_03_05_000000_testing_setup.php` adds `customer_id`, `user_type` and `user_level` to testbench's existing `users` table in `up()` and drops them in `down()`. The suite migrates up and rolls back every run, and PostgreSQL never reclaims a dropped column's slot — `attnum` only ever climbs. My local test database had reached:

```
users attnum high-water: 1598
live columns:               8
dropped columns:         1590
```

Two short of the hard 1600-column ceiling, at which point `setUp` itself starts failing with `SQLSTATE[54011]` and the failures scatter across unrelated tests. That is roughly 530 accumulated runs.

CI never sees it — fresh container each time — so it stays invisible until a contributor's machine stops working. The fix is for that migration to create its own table rather than mutate testbench's `users`, or for the suite to rebuild the table rather than patch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iDeNdEVXrsSmo3TTDG68o