### PR TITLE
Make the test suite runnable on a clean checkout

### DIFF
--- a/src/CoreServiceProvider.php
+++ b/src/CoreServiceProvider.php
@@ -37,6 +37,21 @@ final class CoreServiceProvider extends ServiceProvider
     #[Override]
     public function register(): void
     {
+        /**
+         * Merge before anything else registers, so every config('stickle.*')
+         * lookup has a value whether or not the application has published the
+         * file. Only publishing it left the whole namespace null on a fresh
+         * install: routes/channels.php built its channel names by sprintf()ing
+         * a null pattern, producing empty channel names whose authorization
+         * closures then received the wrong number of arguments; the UI
+         * components were handed null where they require a string; and the
+         * ModelAttributes observer was gated on a flag that could not be true.
+         *
+         * A published file still wins -- mergeConfigFrom only fills in keys the
+         * application has not set.
+         */
+        $this->mergeConfigFrom(__DIR__.'/../config/stickle.php', 'stickle');
+
         $this->app->register(EventServiceProvider::class);
         $this->app->register(ScheduleServiceProvider::class);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,15 +20,50 @@ class TestCase extends Orchestra
 
     protected $tablePrefix;
 
+    /**
+     * Publishing is per-process, not per-test: the files do not change between
+     * tests and the copy is not free.
+     */
+    private static bool $assetsPublished = false;
+
     #[Override]
     protected function setUp(): void
     {
         parent::setUp();
 
+        $this->publishPackageAssets();
+
         Factory::guessFactoryNamesUsing(
             fn (string $modelName): string => 'StickleApp\\Core\\Laravelstickle\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
 
+    }
+
+    /**
+     * Put the package's built assets where the UI views expect to find them.
+     *
+     * Those views render through app('stickle.vite'), which resolves against a
+     * manifest in the application's public/vendor/stickleapp/core. Nothing in a
+     * checkout puts it there. `npm run build:publish` does, so a developer who
+     * has run it sees these tests pass while CI -- which never does -- got
+     * ViteManifestNotFoundException from every test that renders a page.
+     *
+     * public/build is committed, so this is a file copy rather than a build,
+     * and it keeps the suite runnable from any checkout state instead of
+     * depending on which npm scripts happen to have been run.
+     */
+    private function publishPackageAssets(): void
+    {
+        if (self::$assetsPublished) {
+            return;
+        }
+
+        Artisan::call('vendor:publish', [
+            '--tag' => 'package-assets',
+            '--force' => true,
+        ]);
+
+        self::$assetsPublished = true;
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
Two commits, one concern: the suite depended on local state that CI does not have. Each problem was masked by the one before it, which is why they surfaced one at a time rather than together.

| Missing on CI | Symptom | Fix |
| --- | --- | --- |
| skeleton `.env` | `MissingAppKeyException` | #43 (merged) |
| published `config/stickle.php` | `TypeError`, `ArgumentCountError` | commit 1 here |
| published `package-assets` | `ViteManifestNotFoundException` | commit 2 here |

---

## 1. Merge the package config

`CoreServiceProvider` publishes `config/stickle.php` but never merges it. On any installation that has not run `vendor:publish`, the whole `stickle.*` namespace resolves to **null**.

**This is not only a CI problem.** An application that installs the package and does not immediately publish the config gets:

- `routes/channels.php` building channel names by `sprintf()`-ing a null pattern:
  ```php
  Broadcast::channel(sprintf((string) config('stickle.broadcasting.channels.object'), '{model}', '{id}'), fn ($user, $model, $id) => …)
  ```
  `sprintf('', '{model}', '{id}')` produces an empty channel name, whose authorization closure then receives one argument where three are expected — `ArgumentCountError` from inside `Broadcaster`.
- UI components handed `null` where their constructors require `string` — `TypeError` rendering `live.blade.php`.
- The `ModelAttributes` observer gated on a flag that cannot be true, which `tests/TestCase.php` already sets by hand with a comment explaining why.
- `routes/web.php` unable to build its model route pattern — which d8dc638 worked around with a fallback rather than fixing at the source.

`mergeConfigFrom` in `register()` gives every lookup a value. A published file still wins; it only fills in keys the application has not set.

## 2. Publish the package assets in the suite

The UI views render through `app('stickle.vite')`, which resolves against a manifest in the application's `public/vendor/stickleapp/core`. Nothing in a checkout puts it there — `npm run build:publish` does, so a developer who has run it passes and CI, which never does, gets `ViteManifestNotFoundException` from every test that renders a page.

`public/build` is committed, so `TestCase` publishes it as a file copy, once per process. This keeps `vendor/bin/pest` working from any checkout state rather than depending on which npm scripts happen to have been run.

---

## Verified against the CI condition, not inferred

My machine had both a published `config/stickle.php` (dating from February) and published assets — plus a stale `hot` file, whose presence makes Vite skip the manifest lookup entirely. That is why none of this ever appeared locally.

Removing each reproduced the corresponding CI failure exactly: same exceptions, same lines. The full suite then ran with **both** the published config and the published assets absent:

```
Tests:  280 passed, 1 skipped (693 assertions)
```

PHPStan level 8, Pint and Rector clean.

## Follow-up, not included

`d8dc638`'s fallback in `routes/web.php` is redundant once the config merges. Harmless, but it could be simplified in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iDeNdEVXrsSmo3TTDG68o
