### PR TITLE
Stop the rollup grain docblock from making its own guard dead code

### DIFF
--- a/src/Contracts/AnalyticsRepositoryContract.php
+++ b/src/Contracts/AnalyticsRepositoryContract.php
@@ -16,9 +16,14 @@ interface AnalyticsRepositoryContract
     ): void;
 
     /**
-     * Aggregate newly written requests into the rollup table for one grain.
+     * Aggregate newly written requests into the rollup table for one grain:
+     * '1min', '5min', '1hr' or '1day'.
      *
-     * @param  '1min'|'5min'|'1hr'|'1day'  $grain
+     * Deliberately typed as a plain string rather than narrowed to those four
+     * literals. The grain is interpolated into a SQL function name, so the
+     * implementation whitelists it at runtime -- and narrowing here would make
+     * that guard provably dead code, which PHPStan reports as an error rather
+     * than letting an interface's docblock stand in for a check.
      */
     public function rollupRequests(
         string $grain


### PR DESCRIPTION
The one real failure among the four red checks on `main` at `c8e9330`.

```
Call to function in_array() with arguments '1day'|'1hr'|'1min'|'5min',
array{'1min', '5min', '1hr', '1day'} and true will always evaluate to true.
```

PHPStan is right. `AnalyticsRepositoryContract` narrowed `$grain` to those four literals, so the whitelist in `PostgresAnalyticsRepository::rollupRequests()` could never reject anything and read as dead code.

**The guard stays and the docblock widens**, rather than the other way round. The grain is interpolated into a SQL function name, and an interface docblock is a claim about callers rather than a check on them — the implementation is where that has to be enforced. Callers still get a clear error for a bad grain from the `match` in `RollupRequestsCommand`.

### Why it passed locally

CI runs **PHP 8.3**; this machine runs 8.4, and `composer.lock` is untracked so CI resolves its own analyzer version. Clearing PHPStan's result cache did not reproduce it — only the version gap explains it. Worth noting that a clean local `composer analyse` is not proof for this repository.

### The other three red checks on c8e9330 were not code problems

- **Fix PHP code style issues** — the job was *cancelled*, not failed, and its logs have expired. Pint passes against `c8e9330` (`{"result":"pass"}`), so there was nothing to fix. A cancelled job surfaces as run-level failure.
- **Deploy VitePress site to Pages** — `startup_failure` with zero jobs, meaning GitHub never started it. `deploy.yml` is byte-identical between `7c822bd` (succeeded) and `c8e9330`, and #44 touched only two PHP files. #42 and #44 merged close together and both queued on the `pages` concurrency group. **Re-dispatched manually and it succeeded**, confirming it was environmental.
- **run-tests** — was still `queued`, never ran.

### Verified

Rector, Pint and PHPStan clean; `280 passed, 1 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iDeNdEVXrsSmo3TTDG68o