### PR TITLE
Capture the session and IP before enqueueing the auth event write

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+### Authentication events now record the session and IP on every queue driver
+
+No action needed. Recorded here because it changes what the data means.
+
+`AuthenticatableEventListener` was a queued listener, so it was constructed by
+the **worker's** container and the `Illuminate\Http\Request` it injected was a
+synthetic CLI request -- no session, no client IP. Every authentication event row
+written under a real queue driver therefore has `session_uid` and `ip_address`
+set to null. Only `QUEUE_CONNECTION=sync` was unaffected, because the job runs
+inline while the real request is still bound.
+
+The listener now runs on the request thread, where those values exist, and
+dispatches `RecordAuthenticationEventJob` carrying them. The database write is
+still queued; only the capture moved. The job never touches a request, so it
+cannot regress this way again.
+
+**Existing rows cannot be backfilled** -- the session and IP were never recorded,
+so there is nothing to recover. If you have been joining authentication events to
+sessions and getting nothing, this is why. Rows written from here on are correct.
+
+`PageListener` and `TrackListener` are unchanged and remain queued: their request
+state is captured upstream by `RequestLogger` and travels on a `RequestDto`.
+
 ### Check `STICKLE_TRACK_SERVER_AUTHENTICATION_EVENTS_TRACKED` in your `.env`
 
 **If you ran `php artisan stickle:install` before 2026-08-26, your `.env` is

--- a/src/Jobs/RecordAuthenticationEventJob.php
+++ b/src/Jobs/RecordAuthenticationEventJob.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StickleApp\Core\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use StickleApp\Core\Models\Request;
+
+/**
+ * Write one authentication event row.
+ *
+ * Everything the row needs arrives on the constructor, captured while the real
+ * request was still bound. Nothing here may reach for a Request, a session or
+ * the authenticated user: on a queue worker those resolve to a synthetic CLI
+ * request, which is how session_uid and ip_address came back null on every
+ * driver except sync.
+ */
+class RecordAuthenticationEventJob implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @param  array<string, mixed>  $properties
+     */
+    public function __construct(
+        public string $modelClass,
+        public string $objectUid,
+        public ?string $sessionUid,
+        public ?string $ipAddress,
+        public Carbon $timestamp,
+        public array $properties,
+    ) {}
+
+    public function handle(): void
+    {
+        Log::debug(self::class, [
+            'modelClass' => $this->modelClass,
+            'objectUid' => $this->objectUid,
+        ]);
+
+        Request::query()->create([
+            'type' => 'event',
+            'model_class' => $this->modelClass,
+            'object_uid' => $this->objectUid,
+            'session_uid' => $this->sessionUid,
+            'ip_address' => $this->ipAddress,
+            'timestamp' => $this->timestamp,
+            'properties' => $this->properties,
+        ]);
+    }
+}

--- a/src/Listeners/AuthenticatableEventListener.php
+++ b/src/Listeners/AuthenticatableEventListener.php
@@ -13,17 +13,30 @@ use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Events\Validated;
 use Illuminate\Auth\Events\Verified;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
 use StickleApp\Core\Contracts\AnalyticsRepositoryContract;
-use StickleApp\Core\Models\Request as StickleRequest;
+use StickleApp\Core\Jobs\RecordAuthenticationEventJob;
 use StickleApp\Core\Support\ClassUtils;
 
-class AuthenticatableEventListener implements ShouldQueue
+/**
+ * Deliberately NOT ShouldQueue.
+ *
+ * A queued listener is constructed by the worker's container, so the Request it
+ * injects is a synthetic CLI request -- no session, no client IP. This has to
+ * run while the real request is still bound, which is the only moment those
+ * values exist. The database write is what goes on the queue, via
+ * RecordAuthenticationEventJob, which carries the captured values rather than
+ * re-reading them.
+ *
+ * PageListener and TrackListener stay queued because their request state was
+ * already captured upstream by RequestLogger and rides in on a RequestDto.
+ * Laravel's auth events carry no such payload, so the capture happens here.
+ */
+class AuthenticatableEventListener
 {
     /**
      * Create the event listener.
@@ -43,25 +56,19 @@ class AuthenticatableEventListener implements ShouldQueue
         ];
 
         /**
-         * The request is the only source for any of this.
+         * The request is the only source for the session and the IP, and this
+         * is the only moment they are available. Read them here and hand them
+         * to the job as plain values.
          *
-         * session_uid held `new DateTime` -- a timestamp in the column that
-         * joins an event to its session. And ip_address and timestamp were
+         * session_uid once held `new DateTime` -- a timestamp in the column
+         * that joins an event to its session. ip_address and timestamp were
          * read off $event->payload, which no Illuminate\Auth\Events class
-         * defines, so the read raised Undefined property and the row was never
-         * written at all.
+         * defines, so the read raised Undefined property and no row was written
+         * at all.
          */
-        StickleRequest::query()->create([
-            'type' => 'event',
-            'model_class' => ClassUtils::storeModelClass($event->user),
-            'object_uid' => (string) $event->user->getKey(),
-            'session_uid' => $this->request->hasSession()
-                ? $this->request->session()->getId()
-                : null,
-            'ip_address' => $this->request->header('X-Forwarded-For') ?: $this->request->ip(),
-            'timestamp' => Date::now(),
-            'properties' => $properties,
-        ]);
+        dispatch(new RecordAuthenticationEventJob(modelClass: ClassUtils::storeModelClass($event->user), objectUid: (string) $event->user->getKey(), sessionUid: $this->request->hasSession()
+            ? $this->request->session()->getId()
+            : null, ipAddress: $this->request->header('X-Forwarded-For') ?: $this->request->ip(), timestamp: Date::now(), properties: $properties));
     }
 
     /**

--- a/tests/Unit/Listeners/AuthenticationEventQueueTest.php
+++ b/tests/Unit/Listeners/AuthenticationEventQueueTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Auth\Events\Login;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Http\Request;
+use Illuminate\Session\ArraySessionHandler;
+use Illuminate\Session\Store;
+use Illuminate\Support\Facades\Queue;
+use StickleApp\Core\Contracts\AnalyticsRepositoryContract;
+use StickleApp\Core\Jobs\RecordAuthenticationEventJob;
+use StickleApp\Core\Listeners\AuthenticatableEventListener;
+use StickleApp\Core\Models\Request as StickleRequest;
+use Workbench\App\Models\User;
+
+const CAPTURED_SESSION = 'c0ffee01c0ffee02c0ffee03c0ffee04c0ffee05';
+const CAPTURED_IP = '203.0.113.9';
+
+function requestOnTheWebThread(): Request
+{
+    $request = Request::create('/login', 'POST', server: ['REMOTE_ADDR' => CAPTURED_IP]);
+    $request->setLaravelSession(
+        new Store('stickle_session', new ArraySessionHandler(120), CAPTURED_SESSION)
+    );
+
+    return $request;
+}
+
+/**
+ * The listener used to be ShouldQueue, so onEvent() ran on a worker and the
+ * Request it injected was resolved from the worker's container -- a synthetic
+ * CLI request with no session and no client IP. Both columns came back null on
+ * every queue driver except sync.
+ *
+ * The capture has to happen while the real request is still bound, and only the
+ * write belongs on the queue.
+ */
+test('the session and ip are captured on the web thread and carried by the job', function (): void {
+    $user = User::factory()->create();
+
+    $request = requestOnTheWebThread();
+    app()->instance('request', $request);
+    app()->instance(Request::class, $request);
+
+    Queue::fake();
+
+    $dispatcher = new Dispatcher(app());
+    (new AuthenticatableEventListener($request, Mockery::mock(AnalyticsRepositoryContract::class)))
+        ->subscribe($dispatcher);
+
+    $dispatcher->dispatch(new Login('web', $user, false));
+
+    Queue::assertPushed(
+        RecordAuthenticationEventJob::class,
+        fn (RecordAuthenticationEventJob $recordAuthenticationEventJob): bool => $recordAuthenticationEventJob->sessionUid === CAPTURED_SESSION
+            && $recordAuthenticationEventJob->ipAddress === CAPTURED_IP
+    );
+});
+
+/**
+ * The worker must never need a request. This hands the job a bare one to prove
+ * it is not consulted.
+ */
+test('the job writes the captured values without consulting a request', function (): void {
+    $user = User::factory()->create();
+
+    app()->instance('request', Request::create('/'));
+
+    (new RecordAuthenticationEventJob(
+        modelClass: 'User',
+        objectUid: (string) $user->getKey(),
+        sessionUid: CAPTURED_SESSION,
+        ipAddress: CAPTURED_IP,
+        timestamp: now(),
+        properties: ['name' => Login::class],
+    ))->handle();
+
+    $request = StickleRequest::query()->where('type', 'event')->sole();
+
+    expect($request->session_uid)->toBe(CAPTURED_SESSION)
+        ->and($request->ip_address)->toBe(CAPTURED_IP)
+        ->and($request->model_class)->toBe('User')
+        ->and($request->object_uid)->toBe((string) $user->getKey());
+});

--- a/tests/Unit/Support/ClassDiscoveryTest.php
+++ b/tests/Unit/Support/ClassDiscoveryTest.php
@@ -70,7 +70,7 @@ test('the collision names both classes and points at the fix', function (): void
     } catch (RuntimeException $runtimeException) {
         expect($runtimeException->getMessage())
             ->toContain(Thing::class)
-            ->toContain(\StickleApp\Core\Tests\Fixtures\CollidingModels\Vendor\Thing::class)
+            ->toContain(StickleApp\Core\Tests\Fixtures\CollidingModels\Vendor\Thing::class)
             ->toContain('model_class');
     }
 });


### PR DESCRIPTION
Resolves #51.

## ⚠️ Autonomous decisions — please review

- **Dropped `ShouldQueue` from the listener rather than adding a second queued hop.** Chose making `AuthenticatableEventListener` synchronous and having it dispatch a queued job, over keeping it queued and threading the request state in some other way. Why: a queued listener is constructed by the worker's container by definition, so there is no way to keep it queued *and* have it see the real request. Check: `onEvent()` now runs on the request thread — it reads two values off the request and dispatches; the database write is still queued, so the request thread cost is negligible.
- **New job class rather than reusing `RequestDto`.** Chose a purpose-built `RecordAuthenticationEventJob` carrying six scalars, over building a `RequestDto` (which would also require a `ModelDto`). Why: the DTO exists to carry a page/track payload from `RequestLogger`, and an auth event has neither a URL nor the model metadata `ModelDto` wants. Check: whether you would rather these rows flow through the same DTO as page/track rows for consistency.
- **Left `RequestLogger:86`'s unguarded `$request->session()->getId()` alone.** The listener guards with `hasSession()`; `RequestLogger` does not. Why: out of scope for this issue, and it is on the request thread where a session normally exists. Check: worth its own issue if you run stateless routes through that middleware.

## What changed

`AuthenticatableEventListener implements ShouldQueue` meant `Illuminate\Events\Dispatcher` saw the interface on the handler class and routed through `createQueuedHandlerCallable()`. The listener was therefore built by the **worker's** container, so its injected `Illuminate\Http\Request` was a synthetic CLI request — no session, no client IP. Every authentication event row written under a real queue driver had `session_uid` and `ip_address` null.

Only `sync` was unaffected, because the job runs inline while the real request is still bound. That is why `9b9fbbc` looked correct, and why the existing tests — which call `onEvent()` directly — could not catch it.

The listener now runs on the request thread, reads the session id and IP while they exist, and dispatches `RecordAuthenticationEventJob` carrying them as plain values. Only the write is queued. The job never touches a request, a session, or the authenticated user.

This is the shape `PageListener` and `TrackListener` already use — both stay queued, because their request state is captured upstream by `RequestLogger` and rides in on a `RequestDto`. Laravel's auth events carry no such payload, so for those the capture has to happen in the listener.

## Survey of the other queued classes

Checked all eight others for request-scoped state (`request()`, `session()`, `Auth::`, `auth()`, `->ip()`, `->user()`, `$this->request`):

| Class | Constructor carries | Affected |
|---|---|---|
| `ExportSegmentJob` | `Segment` | no |
| `ImportSegmentJob` | `int`, `string` | no |
| `RecordModelAttributesJob` | `Model` | no |
| `RecordModelRelationshipStatisticJob` | 4 × `string` | no |
| `RecordSegmentStatisticJob` | `int`, `string` | no |
| `ModelAttributeChangedListener` | — | no |
| `PageListener` | repository | no — reads a `RequestDto` |
| `TrackListener` | repository | no — reads a `RequestDto` |

**This listener was the only one.** Everything else takes serialisable scalars, a `Model`, or a DTO.

## Tests

Two new tests covering the halves separately, both of which fail if the capture moves back to the worker:

- the session and IP are captured on the web thread and reach the queued job (`Queue::fake()`, event dispatched through a real `Dispatcher` with a request bound);
- the job writes those values with only a bare request bound, proving the worker never consults one.

## Note for upgraders

`UPGRADE.md` records that **existing rows cannot be backfilled** — the session and IP were never captured, so there is nothing to recover. Anyone who has been joining authentication events to sessions and getting nothing now knows why.

## Gates

`composer refactor`, `composer format`, `composer analyse` (PHPStan level 8) clean; **314 passed / 1 skipped**. The `.githooks/pre-commit` hook ran all four on the commit, and `.githooks/pre-push` (asset freshness) passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iDeNdEVXrsSmo3TTDG68o